### PR TITLE
Create table in database if it does not exits

### DIFF
--- a/app/code/community/EW/UntranslatedStrings/sql/ew_untranslatedstrings_setup/install-1.0.0.php
+++ b/app/code/community/EW/UntranslatedStrings/sql/ew_untranslatedstrings_setup/install-1.0.0.php
@@ -6,35 +6,38 @@ $installer->startSetup();
 
 $tableName = $installer->getTable('ew_untranslatedstrings/string');
 
-$table = new Varien_Db_Ddl_Table();
-$table->setName($tableName);
+if(!$installer->getConnection()->isTableExists($tableName)){
 
-$table->addColumn('id', Varien_Db_Ddl_Table::TYPE_INTEGER, 11, array('nullable' => false, 'identity' => true, 'primary' => true));
-$table->addColumn('store_id', Varien_Db_Ddl_Table::TYPE_INTEGER, 11, array('nullable' => false));
-$table->addColumn('untranslated_string', Varien_Db_Ddl_Table::TYPE_VARCHAR, 255, array('nullable' => false));
-$table->addColumn('translation_code', Varien_Db_Ddl_Table::TYPE_VARCHAR, 255, array('nullable' => false));
-$table->addColumn('translation_module', Varien_Db_Ddl_Table::TYPE_VARCHAR, 255, array('nullable' => true));
-$table->addColumn('locale', Varien_Db_Ddl_Table::TYPE_VARCHAR, 10, array('nullable' => true));
-$table->addColumn('url_found', Varien_Db_Ddl_Table::TYPE_VARCHAR, 255, array('nullable' => true));
-$table->addColumn('date_found', Varien_Db_Ddl_Table::TYPE_DATETIME, null, array('nullable' => false));
+    $table = new Varien_Db_Ddl_Table();
+    $table->setName($tableName);
 
-$installer->getConnection()->createTable($table);
+    $table->addColumn('id', Varien_Db_Ddl_Table::TYPE_INTEGER, 11, array('nullable' => false, 'identity' => true, 'primary' => true));
+    $table->addColumn('store_id', Varien_Db_Ddl_Table::TYPE_INTEGER, 11, array('nullable' => false));
+    $table->addColumn('untranslated_string', Varien_Db_Ddl_Table::TYPE_VARCHAR, 255, array('nullable' => false));
+    $table->addColumn('translation_code', Varien_Db_Ddl_Table::TYPE_VARCHAR, 255, array('nullable' => false));
+    $table->addColumn('translation_module', Varien_Db_Ddl_Table::TYPE_VARCHAR, 255, array('nullable' => true));
+    $table->addColumn('locale', Varien_Db_Ddl_Table::TYPE_VARCHAR, 10, array('nullable' => true));
+    $table->addColumn('url_found', Varien_Db_Ddl_Table::TYPE_VARCHAR, 255, array('nullable' => true));
+    $table->addColumn('date_found', Varien_Db_Ddl_Table::TYPE_DATETIME, null, array('nullable' => false));
 
-$uniqueFields = array(
-    'store_id',
-    'untranslated_string',
-    'translation_code',
-    'locale'
-);
-$installer->getConnection()->addIndex(
-    $tableName,
-    $installer->getIdxName(
+    $installer->getConnection()->createTable($table);
+
+    $uniqueFields = array(
+        'store_id',
+        'untranslated_string',
+        'translation_code',
+        'locale'
+    );
+    $installer->getConnection()->addIndex(
         $tableName,
+        $installer->getIdxName(
+            $tableName,
+            $uniqueFields,
+            Varien_Db_Adapter_Interface::INDEX_TYPE_UNIQUE
+        ),
         $uniqueFields,
         Varien_Db_Adapter_Interface::INDEX_TYPE_UNIQUE
-    ),
-    $uniqueFields,
-    Varien_Db_Adapter_Interface::INDEX_TYPE_UNIQUE
-);
+    );
+}
 
 $installer->endSetup();


### PR DESCRIPTION
I am using it in a project where I have installed in my local environment but not in production.
Every time I update my local bbdd with production bbdd I get an error because the extension tries to create `ew_untranslatedstrings_strings` table when it already exists.

I think this check can be also useful to other users.
